### PR TITLE
chore: npm audit fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,17 @@
     "async"
   ],
   "author": "Peter Maude",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "@types/chrome": "^0.0.299",
+    "@types/jsdom": "^21.1.7",
+    "@vitest/ui": "^3.2.4",
+    "happy-dom": "^20.0.1",
+    "jsdom": "^26.1.0",
+    "premove": "^4.0.0",
+    "vitest": "^3.2.4"
+  },
+  "dependencies": {
+    "typescript": "^5.5.3"
+  }
 }


### PR DESCRIPTION
## Summary
- Bumps `@vitest/ui` from ^2.1.8 to ^3.2.4
- Bumps `happy-dom` from ^15.11.6 to ^20.0.1
- Bumps `vitest` from ^2.1.8 to ^3.2.4
- Adds devDependencies and dependencies to main branch package.json

## Test plan
- [ ] Verify `npm install` completes without errors
- [ ] Verify `npm audit` shows no/fewer vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)